### PR TITLE
fix: support neovim 0.8.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -212,21 +212,6 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -240,7 +225,7 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -351,32 +336,10 @@
         "type": "github"
       }
     },
-    "neovim": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "dir": "contrib",
-        "lastModified": 1659275701,
-        "narHash": "sha256-zrL9khNPMwNU4L9kN5Npdxo7NZRkpUT/v3glBuY/+Zk=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "68ec497d52bc8e93e12c74099ee9826b9469c3be",
-        "type": "github"
-      },
-      "original": {
-        "dir": "contrib",
-        "owner": "neovim",
-        "ref": "68ec497d52bc8e93e12c74099ee9826b9469c3be",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
     "nil": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_3",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
@@ -395,7 +358,7 @@
     },
     "nix2vim": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -432,22 +395,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1646254136,
-        "narHash": "sha256-8nQx02tTzgYO21BP/dy5BCRopE8OwE8Drsw98j+Qoaw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3e072546ea98db00c2364b81491b893673267827",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1662096612,
         "narHash": "sha256-R+Q8l5JuyJryRPdiIaYpO5O3A55rT+/pItBrKcy7LM4=",
         "owner": "nixos",
@@ -462,18 +409,18 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1659882243,
-        "narHash": "sha256-XQKHunjMYnzwQWqpqHZJEiXTGHAaT7tLPBh0xICk9LU=",
-        "owner": "DieracDelta",
+        "lastModified": 1665003617,
+        "narHash": "sha256-EXkCo9uMi/aGybJ+fhJuCw9mZyyOg24C4d8HrJ/QyFA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ebb53417e97cec3ddc203ec96810228383720576",
+        "rev": "a989aa4619162ff37bcbb8c2fb1e502658647fb2",
         "type": "github"
       },
       "original": {
-        "owner": "DieracDelta",
-        "ref": "jr/lean-lsp",
+        "owner": "nixos",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -577,10 +524,9 @@
         "lsp_lines-src": "lsp_lines-src",
         "markid-src": "markid-src",
         "neogen-src": "neogen-src",
-        "neovim": "neovim",
         "nil": "nil",
         "nix2vim": "nix2vim",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nvim-async-src": "nvim-async-src",
         "nvim-autopairs-src": "nvim-autopairs-src",
         "nvim-cmp": "nvim-cmp",

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   # Input source for our derivation
   inputs = {
-    nixpkgs.url = "github:DieracDelta/nixpkgs/jr/lean-lsp";
+    nixpkgs.url = "github:nixos/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
     cornelis.url = "github:isovector/cornelis";
 
@@ -36,9 +36,6 @@
       flake = false;
     };
 
-    # 0.7.2 doesn't build for whatever reason
-    # master does, so use that instead...
-    neovim = { url = "github:neovim/neovim?dir=contrib&ref=68ec497d52bc8e93e12c74099ee9826b9469c3be"; };
     telescope-src = {
       url = "github:nvim-telescope/telescope.nvim";
       flake = false;
@@ -140,22 +137,21 @@
 
   };
 
-  outputs = inputs@{ self, flake-utils, nixpkgs, neovim, nix2vim, ... }:
+  outputs = inputs@{ self, flake-utils, nixpkgs, nix2vim, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            neovim.overlay
             (import ./plugins.nix inputs)
             nix2vim.overlay
           ];
         };
         neovimConfig = pkgs.neovimBuilder {
-          # Build with NodeJS
+        #  # Build with NodeJS
           withNodeJs = true;
           withPython3 = true;
-          package = pkgs.neovim;
+          package = nixpkgs.legacyPackages.${system}.neovim-unwrapped;
           imports = [
             ./modules/essentials.nix
             ./modules/lsp.nix
@@ -167,7 +163,7 @@
             ./modules/wilder.nix
             # ./modules/leap.nix
             ./modules/agda.nix
-            ./modules/autopairs.nix
+            #./modules/autopairs.nix
             # TODO uncomment when
             # https://github.com/Olical/conjure/issues/401
             # this will be quite useful

--- a/modules/lsp.nix
+++ b/modules/lsp.nix
@@ -213,28 +213,6 @@ with dsl; {
      --     vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
      -- end
 
-     -- require('lean').setup {
-     --   abbreviations = { builtin = true },
-     --   lsp = {
-     --     enable = false,
-     --   },
-     --   lsp3 = {
-     --     cmd = { "${pkgs.nodePackages.lean-language-server}/bin/lean-language-server", "--stdio", "--", "-M", "4096", "-T", "100000" },
-     --     enable = true,
-     --     mappings = true,
-     --   },
-     --   -- # lsp = {
-     --   -- #   cmd = { "${pkgs.nodePackages.lean-language-server}/bin/lean-language-server"},
-     --   -- # },
-     --   ft = {
-     --     default = "lean3"
-     --   },
-     --   mappings = true,
-     --   lean3 = {
-     --     mouse_events = false;
-     --   },
-     -- }
-
     -- no longer needed b/c lsp_lines
     vim.diagnostic.config({ virtual_text = false, })
 


### PR DESCRIPTION
# Description

Somehow the `neovim/contrib` overlay was changing the version of `libvterm` that was discoverable at build-time if the `neovim` flake input was changed to point to a recent commit of `neovim`. I tried jumping into a `devShell` but it wouldn't get past the configure phase so I couldn't try patching the `neovim` build. Below is a tail of the log output:
```
-- Found LibTermkey: /nix/store/gxgwqaw17nrihn8cqdh8yipiy2n0rydr-libtermkey-0.22/lib/libtermkey.so (Required is at least version "0.22") 
CMake Error at cmake/LibFindMacros.cmake:263 (message):
  REQUIRED PACKAGE NOT FOUND

  LIBVTERM 0.1.3 was found but version 0.3 is the minimum requirement.  This
  package is REQUIRED and you need to install it or adjust CMake
  configuration in order to continue building nvim.

  Relevant CMake configuration variables:

    LIBVTERM_INCLUDE_DIR=/nix/store/927bilw9mffpy19fylh4szr3fr8qiqm1-libvterm-neovim-0.1.3/include
    LIBVTERM_LIBRARY=/nix/store/927bilw9mffpy19fylh4szr3fr8qiqm1-libvterm-neovim-0.1.3/lib/libvterm.so

  You may use CMake GUI, cmake -D or ccmake to modify the values.  Delete
  CMakeCache.txt to discard all values and force full re-detection if
  necessary.

Call Stack (most recent call first):
  cmake/FindLIBVTERM.cmake:10 (libfind_process)
  CMakeLists.txt:505 (find_package)


-- Configuring incomplete, errors occurred!
See also "/build/018y1g47fhcf9yjgsp3fhfgyd9nk47bp-source/build/CMakeFiles/CMakeOutput.log".
See also "/build/018y1g47fhcf9yjgsp3fhfgyd9nk47bp-source/build/CMakeFiles/CMakeError.log".
```

However, I discovered that using the `neovim-unwrapped` package directly from `nixpkgs` works fine. Note that using the `neovim` package from `nixpkgs` fails with the below log (complete):
```
substituteStream(): WARNING: pattern 'Name=Neovim' doesn't match anything in file '/nix/store/vpr36b4sgjlr4nxx7dnwv83pl2a8ss8q-neovim-0.8.0/share/applications/nvim.desktop'
/nix/store/8nbgaxgc2i5p7nkw0df5mbriqy1g9q8b-hook/nix-support/setup-hook: line 115: /nix/store/70vbg9rnflzihhpdfblz7ciflnwy79h2-neovim-0.8.0/bin/nvim-python3: Permission denied
```

This PR also obsoletes the `neovim` flake input, since we're recycling the `nixpkgs` flake input for the `package `attribute of neovimBuilder`.

There may be reasons this PR is unacceptable. I thought I would submit as proof-of-concept in case it contains anything interesting.